### PR TITLE
Change Order to Orders

### DIFF
--- a/src/main/java/at/technikum/springrestbackend/controller/OrderController.java
+++ b/src/main/java/at/technikum/springrestbackend/controller/OrderController.java
@@ -1,6 +1,5 @@
 package at.technikum.springrestbackend.controller;
-
-import at.technikum.springrestbackend.model.Order;
+import at.technikum.springrestbackend.model.Orders;
 import at.technikum.springrestbackend.model.User;
 import at.technikum.springrestbackend.service.OrderService;
 import org.springframework.web.bind.annotation.*;
@@ -18,20 +17,20 @@ public class OrderController {
     }
 
     @GetMapping("/orders")
-    public List<Order> getOrders() {
+    public List<Orders> getOrders() {
         return orderService.getOrders();
     }
 
     @GetMapping("/orders/{id}")
-    public Order getOrder(@PathVariable UUID id) {
+    public Orders getOrder(@PathVariable UUID id) {
         return orderService.getOrder(id);
     }
     @GetMapping("/orders/{user}")
-    public List<Order> getOrdersUsers(User user){
+    public List<Orders> getOrdersUsers(User user){
         return orderService.getOrdersUser(user);
     }
     @PostMapping("/orders")
-    public Order createOrder(@RequestBody Order order){
+    public Orders createOrder(@RequestBody Orders order){
         return orderService.createOrder(order);
     }
 }

--- a/src/main/java/at/technikum/springrestbackend/model/Orders.java
+++ b/src/main/java/at/technikum/springrestbackend/model/Orders.java
@@ -4,7 +4,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +13,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
-public class Order {
+public class Orders {
     @Id
     @Setter(AccessLevel.NONE)
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -23,17 +22,17 @@ public class Order {
     @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
     private  User user;
 
-    @OneToMany(cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
+    @ManyToMany(cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
     private List<Phone> phones = new ArrayList<>();
 
     private Timestamp timestamp;
 
-    public Order(User user){
+    public Orders(User user){
         this.user = user;
         this.timestamp = new Timestamp(System.currentTimeMillis());
     }
 
-    public void addPhone(Phone phone){phones.add(phone);}
+   public void addPhone(Phone phone){phones.add(phone);}
 
 
 

--- a/src/main/java/at/technikum/springrestbackend/repository/OrderRepository.java
+++ b/src/main/java/at/technikum/springrestbackend/repository/OrderRepository.java
@@ -1,15 +1,15 @@
 package at.technikum.springrestbackend.repository;
 
-import at.technikum.springrestbackend.model.Order;
+import at.technikum.springrestbackend.model.Orders;
 import at.technikum.springrestbackend.model.User;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface OrderRepository extends CrudRepository<Order, UUID> {
+public interface OrderRepository extends CrudRepository<Orders, UUID> {
     @Override
-    List<Order> findAll();
+    List<Orders> findAll();
 
-    List<Order> findByUser(User user);
+    List<Orders> findByUser(User user);
 }

--- a/src/main/java/at/technikum/springrestbackend/service/OrderService.java
+++ b/src/main/java/at/technikum/springrestbackend/service/OrderService.java
@@ -1,6 +1,6 @@
 package at.technikum.springrestbackend.service;
 
-import at.technikum.springrestbackend.model.Order;
+import at.technikum.springrestbackend.model.Orders;
 import at.technikum.springrestbackend.model.User;
 import at.technikum.springrestbackend.repository.OrderRepository;
 import org.springframework.stereotype.Service;
@@ -17,19 +17,19 @@ public class OrderService {
         this.orderRepository = orderRepository;
     }
 
-    public List<Order> getOrders() {
+    public List<Orders> getOrders() {
         return orderRepository.findAll();
     }
 
-    public Order getOrder(UUID id) {
+    public Orders getOrder(UUID id) {
         return orderRepository.findById(id).orElseThrow();
     }
 
-    public List<Order> getOrdersUser(User user) {
+    public List<Orders> getOrdersUser(User user) {
         return orderRepository.findByUser(user);
     }
 
-    public Order createOrder(Order order) {
+    public Orders createOrder(Orders order) {
         return orderRepository.save(order);
     }
 }


### PR DESCRIPTION
Because: The problem here is that "order" is a reserved keyword in most SQL databases, including MariaDB. It is used to specify the sorting order of query results. In your case, you named your table Order, which conflicts with this reserved keyword.